### PR TITLE
Fix faulty URL and add missing header in table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ tar -xvf azswitch_0.1.4_linux_amd64.tar.gz
 mv azswitch /usr/local/bin/
 ```
 
+### macOS
+```zsh
+#Download the latest release
+curl -LJO https://github.com/eliasericsson/azswitch/releases/download/v0.1.4/azswitch_0.1.4_macOS_64-bit.zip
+
+#Extract the archive contents
+unzip azswitch_0.1.4_macOS_64-bit.zip
+
+#Move the binary to a directory in your path
+mv azswitch ${HOME}/.local/bin
+```
+
+
 ### Windows
 #### Chocolatey
 Install using the Chocolatey package manager, will also install the required dependencies:

--- a/README.md
+++ b/README.md
@@ -10,18 +10,20 @@ Switch quicker between Azure subscriptions
 
 ## Installation
 * [Linux](#ubuntu/debian/arch)
+* [MacOS](#macos)
 * [Windows](#windows)
     * [chocolatey](#chocolatey)
     * [manual](#manual)
+
 
 ### Ubuntu/Debian/Arch
 Copy the binary into your $PATH
 ```sh
 # Download the latest release
-wget https://github.com/eliasericsson/azswitch/releases/download/v0.1.4/azswitch_0.1.4_linux_amd64.tar.gz
+wget https://github.com/eliasericsson/azswitch/releases/download/v0.1.4/azswitch_0.1.4_linux_64-bit.tar.gz
 
 # Extract the archive contents
-tar -xvf azswitch_0.1.4_linux_amd64.tar.gz
+tar -xvf azswitch_0.1.4_linux_64-bit.tar.gz
 
 # Move the binary to a directory in your $PATH
 mv azswitch /usr/local/bin/


### PR DESCRIPTION
Fixes the Linux instructions to point to a correct package URL.